### PR TITLE
Grid3Dクラスを新設し、Grid2DはGrid3Dの機能制限版として再リリースした

### DIFF
--- a/PreProcess.py
+++ b/PreProcess.py
@@ -43,7 +43,7 @@ def extract_source(filepath:str, curdir:str):
                 if(re.match(INCLUDE_RE, l)):
                     re_result = re.search(INCLUDE_RE, l)
                     include_path = re_result.group("include_path")
-                    dirname = os.path.dirname(os.path.abspath(filepath))
+                    dirname = os.path.dirname(os.path.abspath(pathlib.Path(curdir, filepath)))
                     extract_source(include_path, dirname)
 
                 # defineを処理する

--- a/module/Grid2D.cpp
+++ b/module/Grid2D.cpp
@@ -1,124 +1,24 @@
 ﻿#ifndef __INCLUDED_GRID2D__
 #define __INCLUDED_GRID2D__
 
-#include "Position.cpp"
+#include "Grid3D.cpp"
 
-#include <array>
-#include <cassert>
-#include <cstdint>
-#include <iostream>
-#include <queue>
-#include <vector>
-
-/**
-    @brief    二次元のグリッドを表すクラス
-
-    @tparam    T   格納する型
- */
+//! @brief 二次元のグリッドを表すクラス
+//! @tparam T 格納する型
 template <class T>
-class Grid2D
+class Grid2D : public Grid3D<T>
 {
+    using BaseClass = Grid3D<T>;
+
   public:
-    class Iterator
+    using Iterator = BaseClass::Iterator; //!< イテレータの型
+
+  public:
+    //! @brief デフォルトコンストラクタ
+    Grid2D() : BaseClass()
     {
-      public:
-        //! @brief デフォルトコンストラクタ
-        Iterator() : m_pGrid(nullptr), m_position()
-        {
-        }
+    }
 
-        //! @brief コンストラクタ
-        //! @param grid グリッド
-        //! @param position 初期座標
-        Iterator(Grid2D &grid, const POSITION &position) : m_pGrid(&grid), m_position(position)
-        {
-        }
-
-        //! @brief コピーコンストラクタ
-        //! @param rhs コピー元
-        Iterator(const Iterator &rhs) : m_pGrid(rhs.m_pGrid), m_position(rhs.m_position)
-        {
-        }
-
-        //! @brief コピー代入演算子
-        //! @param rhs コピー元
-        //! @return 自身の参照
-        Iterator &operator=(const Iterator &rhs)
-        {
-            m_pGrid = rhs.m_pGrid;
-            m_position = rhs.m_position;
-
-            return *this;
-        }
-
-        //! @brief 加算代入演算子
-        //! @param rhs 右辺
-        //! @return 自身の参照
-        Iterator &operator+=(const POSITION &rhs)
-        {
-            m_position += rhs;
-
-            return *this;
-        }
-
-        //! @brief 減算代入演算子
-        //! @param rhs 右辺
-        //! @return 自身の参照
-        Iterator &operator-=(const POSITION &rhs)
-        {
-            m_position -= rhs;
-
-            return *this;
-        }
-        //! @brief 加算演算子
-        //! @param rhs 右辺
-        //! @return 加算の結果
-        Iterator operator+(const POSITION &rhs) const
-        {
-            Iterator retval = *this;
-            retval += rhs;
-
-            return retval;
-        }
-
-        //! @brief 減算演算子
-        //! @param rhs 右辺
-        //! @return 減算の結果
-        Iterator operator-(const POSITION &rhs) const
-        {
-            Iterator retval = *this;
-            retval -= rhs;
-
-            return retval;
-        }
-
-        //! @brief 参照演算子
-        //! @return 指している先の参照
-        T &operator*() const
-        {
-            return m_pGrid->Ref(m_position.X, m_position.Y);
-        }
-
-        //! @brief 指している先が範囲内か
-        //! @return 範囲内ならtrue
-        bool IsInner() const
-        {
-            return m_pGrid->IsInner(m_position.X, m_position.Y);
-        }
-
-        //! @brief インデックス取得
-        //! @return インデックス
-        int64_t GetIndex() const
-        {
-            return m_pGrid->GetIndex(m_position.X, m_position.Y);
-        }
-
-      private:
-        Grid2D *m_pGrid;     //!< グリッドのポインタ
-        POSITION m_position; //!< 指している座標
-    };
-
-  public:
     /**
         @brief    コンストラクタ
 
@@ -126,40 +26,8 @@ class Grid2D
         @param[in]    width           幅
         @param[in]    initialValue    初期値
     */
-    Grid2D(int64_t height, int64_t width, T initialValue)
-        : m_data(height * width, initialValue), m_width(width), m_height(height)
+    Grid2D(int64_t H, int64_t W, T initialValue) : BaseClass(H, W, 1, initialValue)
     {
-    }
-
-    //! @brief コピーコンストラクタ
-    //! @param rhs コピー元
-    Grid2D(const Grid2D<T> &rhs)
-        : m_data(rhs.GetHeight() * rhs.GetWidth()), m_width(rhs.GetWidth()), m_height(rhs.GetHeight())
-    {
-        int64_t sz = GetWidth() * GetHeight();
-        for (int64_t idx = 0; idx < sz; ++idx)
-        {
-            m_data[idx] = rhs.m_data[idx];
-        }
-    }
-
-    //! @brief コピー代入演算子
-    //! @param rhs コピー元
-    //! @return 自身の参照
-    Grid2D<T> &operator=(const Grid2D<T> &rhs)
-    {
-        m_width = rhs.GetWidth();
-        m_height = rhs.GetHeight();
-
-        int64_t sz = GetWidth() * GetHeight();
-        m_data.resize(sz);
-
-        for (int64_t idx = 0; idx < sz; ++idx)
-        {
-            m_data[idx] = rhs.m_data[idx];
-        }
-
-        return *this;
     }
 
     /**
@@ -172,7 +40,7 @@ class Grid2D
      */
     T &Ref(int64_t x, int64_t y)
     {
-        return const_cast<T &>(Get(x, y));
+        return const_cast<T &>(BaseClass::Get(x, y, 0));
     }
 
     /**
@@ -185,27 +53,7 @@ class Grid2D
      */
     const T &Get(int64_t x, int64_t y) const
     {
-        return m_data[GetIndex(x, y)];
-    }
-
-    /**
-        @brief    高さの取得
-
-        @return ���さ
-     */
-    int64_t GetHeight() const
-    {
-        return m_height;
-    }
-
-    /**
-        @brief    幅の取得
-
-        @return 幅
-     */
-    int64_t GetWidth() const
-    {
-        return m_width;
+        return BaseClass::Get(x, y, 0);
     }
 
     /**
@@ -218,37 +66,7 @@ class Grid2D
      */
     int64_t GetIndex(int64_t x, int64_t y) const
     {
-        assert(IsInner(x, y));
-
-        return y * m_width + x;
-    }
-
-    /**
-        @brief        X座標を取得する
-
-        @param[in]    idx     インデックス
-
-        @return     X座標
-     */
-    int64_t GetX(int64_t idx) const
-    {
-        assert(0 <= idx && idx < m_height * m_width);
-
-        return idx % m_width;
-    }
-
-    /**
-        @brief        Y座標を取得する
-
-        @param[in]    idx     インデックス
-
-        @return     Y座標
-     */
-    int64_t GetY(int64_t idx) const
-    {
-        assert(0 <= idx && idx < m_height * m_width);
-
-        return idx / m_width;
+        return BaseClass::GetIndex(x, y, 0);
     }
 
     /**
@@ -262,61 +80,7 @@ class Grid2D
      */
     bool IsInner(int64_t x, int64_t y) const
     {
-        return 0 <= x && x < m_width && 0 <= y && y < m_height;
-    }
-
-    /**
-        @brief        全てのマスに対して操作する
-
-        @tparam     Func    関数の型
-
-        @param[in]    func    操作する関数(引数としてidxとその地点の値が貰える)
-     */
-    template <class Func>
-    void ForEach(Func func)
-    {
-        for (int i = 0; i < m_width * m_height; ++i)
-        {
-            func(i, m_data[i]);
-        }
-    }
-
-    //! @brief 不等価演算子
-    //! @param rhs 比較先
-    //! @return 不一致ならtrue
-    bool operator!=(const Grid2D<T> &rhs) const
-    {
-        if (GetHeight() != rhs.GetHeight() || GetWidth() != rhs.GetWidth())
-        {
-            return true;
-        }
-        for (int64_t y = 0; y < GetHeight(); ++y)
-        {
-            for (int64_t x = 0; x < GetWidth(); ++x)
-            {
-                if (Get(x, y) != rhs.Get(x, y))
-                {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
-    //! @brief 等価演算子
-    //! @param rhs 比較先
-    //! @return 一致したらtrue
-    bool operator==(const Grid2D<T> &rhs) const
-    {
-        return !operator!=(rhs);
-    }
-
-    //! @brief イテレータ取得
-    //! @param idx インデックス
-    //! @return イテレータ
-    Iterator GetItr(int64_t idx)
-    {
-        return GetItr(GetX(idx), GetY(idx));
+        return BaseClass::IsInner(x, y, 0);
     }
 
     //! @brief イテレータ取得
@@ -325,96 +89,10 @@ class Grid2D
     //! @return イテレータ
     Iterator GetItr(int64_t x, int64_t y)
     {
-        return GetItr({x, y});
+        return GetItr({x, y, 0});
     }
 
-    //! @brief イテレータ取得
-    //! @param position 座標
-    //! @return イテレータ
-    Iterator GetItr(const POSITION &position)
-    {
-        return Iterator(*this, position);
-    }
-
-    //! @brief 特定の値が存在する位置をコンテナに突っ込む
-    //! @tparam CONTAINER コンテナ型(中身はIterator型前提)
-    //! @param out 格納先
-    //! @param val 値
-    std::queue<Iterator> GetPositionsQueueByValue(T val)
-    {
-        std::queue<Iterator> ret;
-        for (int64_t idx = 0; idx < m_data.size(); ++idx)
-        {
-            if (m_data[idx] == val)
-            {
-                ret.push(GetItr(idx));
-            }
-        }
-        return ret;
-    }
-
-  private:
-    std::vector<T> m_data; //!< 本体となる配列
-    int64_t m_width;       //!< 幅
-    int64_t m_height;      //!< 高さ
-
-    template <class U>
-    friend std::istream &operator>>(std::istream &stream, Grid2D<U> &dest);
+    using BaseClass::GetItr;
 };
-
-/**
-    @brief            入力ストリーム演算子
-
-    @tparam    T       Grid2Dに格納する型
-    @param[in]        stream  入力ストリーム
-    @param[in]        dest    入力を受け付ける先のGrid2D
-
-    @return                 入力ストリーム
- */
-template <class T>
-std::istream &operator>>(std::istream &stream, Grid2D<T> &dest)
-{
-    for (int64_t y = 0; y < dest.m_height; ++y)
-    {
-        for (int64_t x = 0; x < dest.m_width; ++x)
-        {
-            stream >> dest.Ref(x, y);
-        }
-    }
-    return stream;
-}
-
-namespace std
-{
-/**
-        @brief	2次元グリッドクラスのハッシュ値を計算する
-
-        @tparam	 Grid2Dを指定
-     */
-template <class T>
-struct hash<Grid2D<T>>
-{
-    /**
-            @brief	呼び出し演算子
-
-            @param[in]	val 対象
-            @return ハッシュ値
-         */
-    size_t operator()(const Grid2D<T> &src) const
-    {
-        size_t retval = 0;
-
-        for (int64_t y = 0; y < src.GetHeight(); ++y)
-        {
-            for (int64_t x = 0; x < src.GetWidth(); ++x)
-            {
-                retval <<= 7;
-                retval ^= src.Get(x, y);
-            }
-        }
-        return retval;
-    }
-};
-} // namespace std
 
 #endif //__INCLUDED_GRID2D__

--- a/module/Grid3D.cpp
+++ b/module/Grid3D.cpp
@@ -128,7 +128,7 @@ class Grid3D
         @param[in]    initialValue    初期値
     */
     Grid3D(int64_t height, int64_t width, int64_t depth, T initialValue)
-        : m_data(height * width, initialValue), m_width(width), m_height(height), m_depth(depth)
+        : m_data(height * width * depth, initialValue), m_width(width), m_height(height), m_depth(depth)
     {
     }
 

--- a/module/Grid3D.cpp
+++ b/module/Grid3D.cpp
@@ -1,4 +1,4 @@
-#ifndef __INCLUDED_GRID3D__
+﻿#ifndef __INCLUDED_GRID3D__
 #define __INCLUDED_GRID3D__
 
 #include "Position.cpp"
@@ -196,7 +196,7 @@ class Grid3D
     /**
         @brief    高さの取得
 
-        @return ���さ
+        @return   高さ
      */
     int64_t GetHeight() const
     {

--- a/module/Grid3D.cpp
+++ b/module/Grid3D.cpp
@@ -1,0 +1,462 @@
+#ifndef __INCLUDED_GRID3D__
+#define __INCLUDED_GRID3D__
+
+#include "Position.cpp"
+
+#include <array>
+#include <cassert>
+#include <cstdint>
+#include <iostream>
+#include <queue>
+#include <vector>
+
+/**
+    @brief    三次元のグリッドを表すクラス
+
+    @tparam    T   格納する型
+ */
+template <class T>
+class Grid3D
+{
+  public:
+    class Iterator
+    {
+      public:
+        //! @brief デフォルトコンストラクタ
+        Iterator() : m_pGrid(nullptr), m_position()
+        {
+        }
+
+        //! @brief コンストラクタ
+        //! @param grid グリッド
+        //! @param position 初期座標
+        Iterator(Grid3D &grid, const POSITION &position) : m_pGrid(&grid), m_position(position)
+        {
+        }
+
+        //! @brief コピーコンストラクタ
+        //! @param rhs コピー元
+        Iterator(const Iterator &rhs) : m_pGrid(rhs.m_pGrid), m_position(rhs.m_position)
+        {
+        }
+
+        //! @brief コピー代入演算子
+        //! @param rhs コピー元
+        //! @return 自身の参照
+        Iterator &operator=(const Iterator &rhs)
+        {
+            m_pGrid = rhs.m_pGrid;
+            m_position = rhs.m_position;
+
+            return *this;
+        }
+
+        //! @brief 加算代入演算子
+        //! @param rhs 右辺
+        //! @return 自身の参照
+        Iterator &operator+=(const POSITION &rhs)
+        {
+            m_position += rhs;
+
+            return *this;
+        }
+
+        //! @brief 減算代入演算子
+        //! @param rhs 右辺
+        //! @return 自身の参照
+        Iterator &operator-=(const POSITION &rhs)
+        {
+            m_position -= rhs;
+
+            return *this;
+        }
+        //! @brief 加算演算子
+        //! @param rhs 右辺
+        //! @return 加算の結果
+        Iterator operator+(const POSITION &rhs) const
+        {
+            Iterator retval = *this;
+            retval += rhs;
+
+            return retval;
+        }
+
+        //! @brief 減算演算子
+        //! @param rhs 右辺
+        //! @return 減算の結果
+        Iterator operator-(const POSITION &rhs) const
+        {
+            Iterator retval = *this;
+            retval -= rhs;
+
+            return retval;
+        }
+
+        //! @brief 参照演算子
+        //! @return 指している先の参照
+        T &operator*() const
+        {
+            return m_pGrid->Ref(m_position.X, m_position.Y, m_position.Z);
+        }
+
+        //! @brief 指している先が範囲内か
+        //! @return 範囲内ならtrue
+        bool IsInner() const
+        {
+            return m_pGrid->IsInner(m_position.X, m_position.Y, m_position.Z);
+        }
+
+        //! @brief インデックス取得
+        //! @return インデックス
+        int64_t GetIndex() const
+        {
+            return m_pGrid->GetIndex(m_position.X, m_position.Y, m_position.Z);
+        }
+
+      private:
+        Grid3D *m_pGrid;     //!< グリッドのポインタ
+        POSITION m_position; //!< 指している座標
+    };
+
+  public:
+    /**
+        @brief    コンストラクタ
+
+        @param[in]    height          高さ
+        @param[in]    width           幅
+        @param[in]    depth           深さ
+        @param[in]    initialValue    初期値
+    */
+    Grid3D(int64_t height, int64_t width, int64_t depth, T initialValue)
+        : m_data(height * width, initialValue), m_width(width), m_height(height), m_depth(depth)
+    {
+    }
+
+    //! @brief コピーコンストラクタ
+    //! @param rhs コピー元
+    Grid3D(const Grid3D<T> &rhs)
+        : m_data(rhs.GetHeight() * rhs.GetWidth() * rhs.GetDepth()), m_width(rhs.GetWidth()), m_height(rhs.GetHeight()),
+          m_depth(rhs.GetDepth())
+    {
+        int64_t sz = GetWidth() * GetHeight() * GetDepth();
+        for (int64_t idx = 0; idx < sz; ++idx)
+        {
+            m_data[idx] = rhs.m_data[idx];
+        }
+    }
+
+    //! @brief コピー代入演算子
+    //! @param rhs コピー元
+    //! @return 自身の参照
+    Grid3D<T> &operator=(const Grid3D<T> &rhs)
+    {
+        m_width = rhs.GetWidth();
+        m_height = rhs.GetHeight();
+        m_depth = rhs.GetDepth();
+
+        int64_t sz = GetWidth() * GetHeight() * GetDepth();
+        m_data.resize(sz);
+
+        for (int64_t idx = 0; idx < sz; ++idx)
+        {
+            m_data[idx] = rhs.m_data[idx];
+        }
+
+        return *this;
+    }
+
+    /**
+        @brief            指定した座標の値にアクセスする
+
+        @param[in]    x   X座標
+        @param[in]    y   Y座標
+        @param[in]    z   Z座標
+
+        @return         目的の座標の参照
+     */
+    T &Ref(int64_t x, int64_t y, int64_t z)
+    {
+        return const_cast<T &>(Get(x, y, z));
+    }
+
+    /**
+        @brief            指定した座標の値を読み取る
+
+        @param[in]    x   X座標
+        @param[in]    y   Y座標
+        @param[in]    z   Z座標
+
+        @return         目的の座標の参照
+     */
+    const T &Get(int64_t x, int64_t y, int64_t z) const
+    {
+        return m_data[GetIndex(x, y, z)];
+    }
+
+    /**
+        @brief    高さの取得
+
+        @return ���さ
+     */
+    int64_t GetHeight() const
+    {
+        return m_height;
+    }
+
+    /**
+        @brief    幅の取得
+
+        @return 幅
+     */
+    int64_t GetWidth() const
+    {
+        return m_width;
+    }
+
+    /**
+        @brief    深さの取得
+
+        @return 深さ
+     */
+    int64_t GetDepth() const
+    {
+        return m_depth;
+    }
+
+    /**
+        @brief    Indexの取得
+
+        @param[in]    x       X座標
+        @param[in]    y       Y座標
+        @param[in]    z       Z座標
+
+        @return     Index
+     */
+    int64_t GetIndex(int64_t x, int64_t y, int64_t z) const
+    {
+        assert(IsInner(x, y, z));
+
+        return z * m_height * m_width + y * m_width + x;
+    }
+
+    /**
+        @brief        X座標を取得する
+
+        @param[in]    idx     インデックス
+
+        @return     X座標
+     */
+    int64_t GetX(int64_t idx) const
+    {
+        assert(0 <= idx && idx < m_height * m_width * m_depth);
+
+        return idx % m_width;
+    }
+
+    /**
+        @brief        Y座標を取得する
+
+        @param[in]    idx     インデックス
+
+        @return     Y座標
+     */
+    int64_t GetY(int64_t idx) const
+    {
+        assert(0 <= idx && idx < m_height * m_width * m_depth);
+
+        return (idx / m_width) % m_height;
+    }
+
+    /**
+        @brief        Z座標を取得する
+
+        @param[in]    idx     インデックス
+
+        @return     Z座標
+     */
+    int64_t GetZ(int64_t idx) const
+    {
+        assert(0 <= idx && idx < m_height * m_width * m_depth);
+
+        return idx / (m_width * m_height);
+    }
+
+    /**
+        @brief            座標がグリッドの内部か否か
+
+        @param[in]    x       X座標
+        @param[in]    y       Y座標
+        @param[in]    z       Z座標
+
+        @retval     true    グリッドの内部にいる
+        @retval     false   グリッドの外側
+     */
+    bool IsInner(int64_t x, int64_t y, int64_t z) const
+    {
+        return 0 <= x && x < m_width && 0 <= y && y < m_height && 0 <= z && z < m_depth;
+    }
+
+    /**
+        @brief        全てのマスに対して操作する
+
+        @tparam     Func    関数の型
+
+        @param[in]    func    操作する関数(引数としてidxとその地点の値が貰える)
+     */
+    template <class Func>
+    void ForEach(Func func)
+    {
+        for (int i = 0; i < m_width * m_height * m_depth; ++i)
+        {
+            func(i, m_data[i]);
+        }
+    }
+
+    //! @brief 不等価演算子
+    //! @param rhs 比較先
+    //! @return 不一致ならtrue
+    bool operator!=(const Grid3D<T> &rhs) const
+    {
+        if (GetHeight() != rhs.GetHeight() || GetWidth() != rhs.GetWidth() || GetDepth() != rhs.GetDepth())
+        {
+            return true;
+        }
+        for (int64_t z = 0; z < GetDepth(); ++z)
+        {
+            for (int64_t y = 0; y < GetHeight(); ++y)
+            {
+                for (int64_t x = 0; x < GetWidth(); ++x)
+                {
+                    if (Get(x, y, z) != rhs.Get(x, y, z))
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    //! @brief 等価演算子
+    //! @param rhs 比較先
+    //! @return 一致したらtrue
+    bool operator==(const Grid3D<T> &rhs) const
+    {
+        return !operator!=(rhs);
+    }
+
+    //! @brief イテレータ取得
+    //! @param idx インデックス
+    //! @return イテレータ
+    Iterator GetItr(int64_t idx)
+    {
+        return GetItr(GetX(idx), GetY(idx), GetZ(idx));
+    }
+
+    //! @brief イテレータ取得
+    //! @param x X座標
+    //! @param y Y座標
+    //! @param z Z座標
+    //! @return イテレータ
+    Iterator GetItr(int64_t x, int64_t y, int64_t z)
+    {
+        return GetItr({x, y, z});
+    }
+
+    //! @brief イテレータ取得
+    //! @param position 座標
+    //! @return イテレータ
+    Iterator GetItr(const POSITION &position)
+    {
+        return Iterator(*this, position);
+    }
+
+    //! @brief 特定の値が存在する位置をコンテナに突っ込む
+    //! @tparam CONTAINER コンテナ型(中身はIterator型前提)
+    //! @param out 格納先
+    //! @param val 値
+    std::queue<Iterator> GetPositionsQueueByValue(T val)
+    {
+        std::queue<Iterator> ret;
+        for (int64_t idx = 0; idx < m_data.size(); ++idx)
+        {
+            if (m_data[idx] == val)
+            {
+                ret.push(GetItr(idx));
+            }
+        }
+        return ret;
+    }
+
+  private:
+    std::vector<T> m_data; //!< 本体となる配列
+    int64_t m_width;       //!< 幅
+    int64_t m_height;      //!< 高さ
+    int64_t m_depth;       //!< 深さ
+
+    template <class U>
+    friend std::istream &operator>>(std::istream &stream, Grid3D<U> &dest);
+};
+
+/**
+    @brief            入力ストリーム演算子
+
+    @tparam    T       Grid3Dに格納する型
+    @param[in]        stream  入力ストリーム
+    @param[in]        dest    入力を受け付ける先のGrid2D
+
+    @return                 入力ストリーム
+ */
+template <class T>
+std::istream &operator>>(std::istream &stream, Grid3D<T> &dest)
+{
+    for (int64_t z = 0; z < dest.m_depth; ++z)
+    {
+        for (int64_t y = 0; y < dest.m_height; ++y)
+        {
+            for (int64_t x = 0; x < dest.m_width; ++x)
+            {
+                stream >> dest.Ref(x, y, z);
+            }
+        }
+    }
+    return stream;
+}
+
+namespace std
+{
+/**
+        @brief	3次元グリッドクラスのハッシュ値を計算する
+
+        @tparam	 Grid3Dを指定
+     */
+template <class T>
+struct hash<Grid3D<T>>
+{
+    /**
+            @brief	呼び出し演算子
+
+            @param[in]	val 対象
+            @return ハッシュ値
+         */
+    size_t operator()(const Grid3D<T> &src) const
+    {
+        size_t retval = 0;
+
+        for (int64_t z = 0; z < src.GetDepth(); ++z)
+        {
+            for (int64_t y = 0; y < src.GetHeight(); ++y)
+            {
+                for (int64_t x = 0; x < src.GetWidth(); ++x)
+                {
+                    retval <<= 7;
+                    retval ^= src.Get(x, y, z);
+                }
+            }
+        }
+        return retval;
+    }
+};
+} // namespace std
+
+#endif //__INCLUDED_GRID3D__

--- a/module/Position.cpp
+++ b/module/Position.cpp
@@ -35,6 +35,20 @@ struct POSITION
         return POSITION(0, -1);
     }
 
+    //! @brief 前移動の差分を取得
+    //! @return 前移動の差分
+    static POSITION F()
+    {
+        return POSITION(0, 0, 1);
+    }
+
+    //! @brief 後移動の差分を取得
+    //! @return 後移動の差分
+    static POSITION B()
+    {
+        return POSITION(0, 0, -1);
+    }
+
     //! @brief RLDUから座標差分を取得する
     //! @param dir R,L,D,Uの文字
     //! @return 対応する方向
@@ -99,20 +113,21 @@ struct POSITION
 
   public:
     //! @brief デフォルトコンストラクタ
-    POSITION() : X(0), Y(0)
+    POSITION() : X(0), Y(0), Z(0)
     {
     }
 
     //! @brief コンストラクタ
     //! @param x
     //! @param y
-    POSITION(int64_t x, int64_t y) : X(x), Y(y)
+    //! @param z
+    POSITION(int64_t x, int64_t y, int64_t z = 0) : X(x), Y(y), Z(z)
     {
     }
 
     //! @brief コピーコンストラクタ
     //! @param rhs コピー元
-    POSITION(const POSITION &rhs) : X(rhs.X), Y(rhs.Y)
+    POSITION(const POSITION &rhs) : X(rhs.X), Y(rhs.Y), Z(rhs.Z)
     {
     }
 
@@ -123,6 +138,7 @@ struct POSITION
     {
         X = rhs.X;
         Y = rhs.Y;
+        Z = rhs.Z;
 
         return *this;
     }
@@ -134,6 +150,7 @@ struct POSITION
     {
         X += rhs.X;
         Y += rhs.Y;
+        Z += rhs.Z;
 
         return *this;
     }
@@ -145,6 +162,7 @@ struct POSITION
     {
         X -= rhs.X;
         Y -= rhs.Y;
+        Z -= rhs.Z;
 
         return *this;
     }
@@ -156,6 +174,7 @@ struct POSITION
     {
         X *= rhs.X;
         Y *= rhs.Y;
+        Z *= rhs.Z;
 
         return *this;
     }
@@ -196,6 +215,7 @@ struct POSITION
   public:
     int64_t X; //!< X座標
     int64_t Y; //!< Y座標
+    int64_t Z; //!< Z座標
 };
 
 #endif //___INCLUDED_POSITION___

--- a/module/Position.cpp
+++ b/module/Position.cpp
@@ -1,4 +1,4 @@
-#ifndef ___INCLUDED_POSITION___
+﻿#ifndef ___INCLUDED_POSITION___
 #define ___INCLUDED_POSITION___
 
 #include <array>


### PR DESCRIPTION
Grid3Dクラスを作った  
機能自体はGrid2Dと同じで、次元だけ拡張してある  
Grid2DはGrid3Dの機能制限版として再リリースしているが、既存のGrid2Dとまったく同じ構文で使用可能